### PR TITLE
feature: Add GitHub API token support via GH_TOKEN/GITHUB_TOKEN

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@
       filters:
         description: 'Filters to apply to versions. Example: "LAST.*.*"'
         required: false
+      github-token:
+        description: 'GitHub API token for authenticated requests (increases rate limit from 60 to 5000 requests/hour)'
+        required: false
+        default: ""
   outputs:
     versions:
       description: 'Found versions'
@@ -33,6 +37,8 @@
   runs:
       image: "docker://scylladb/github-actions:get-version-v0.4.4"
       using: "docker"
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
       args:
         - --source=${{ inputs.source }}
         - --mvn-artifact-id=${{ inputs.mvn-artifact-id }}

--- a/sources/github/github.go
+++ b/sources/github/github.go
@@ -51,6 +51,7 @@ func getNextLink(resp *http.Response) string {
 func executeQuery(
 	cl *http.Client,
 	url string,
+	token string,
 	extractor versionExtractor,
 ) (out version.Versions, ignored []types.IgnoredVersion, next string, err error) {
 	var rq *http.Request
@@ -59,6 +60,9 @@ func executeQuery(
 		return nil, nil, "", err
 	}
 	rq.Header.Set("Accept", "application/vnd.github+json")
+	if token != "" {
+		rq.Header.Set("Authorization", "Bearer "+token)
+	}
 	resp, err := cl.Do(rq)
 	if err != nil {
 		return nil, nil, "",
@@ -127,7 +131,7 @@ func getVersionsFromGitHub(
 ) (out version.Versions, ignored []types.IgnoredVersion, err error) {
 	for url != "" {
 		for retry := 0; ; retry++ {
-			versions, ignoredVersions, nextURL, queryErr := executeQuery(cl, url, extractor)
+			versions, ignoredVersions, nextURL, queryErr := executeQuery(cl, url, params.GitHubToken, extractor)
 			if queryErr != nil {
 				if retry >= params.RetryMax {
 					return nil, nil, fmt.Errorf("failed to execute query to %s, last error: %w", url, queryErr)

--- a/sources/github/github_test.go
+++ b/sources/github/github_test.go
@@ -1,0 +1,62 @@
+package github
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/scylladb-actions/get-version/types"
+	"github.com/scylladb-actions/get-version/version"
+)
+
+func TestExecuteQueryWithToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer test-token-123" {
+			t.Errorf("expected Authorization header %q, got %q", "Bearer test-token-123", auth)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"name":"1.0.0","prerelease":false,"draft":false}]`))
+	}))
+	defer server.Close()
+
+	extractor := func(r *http.Response) (version.Versions, []types.IgnoredVersion, error) {
+		return extractVersionsFromRelease(r, "")
+	}
+
+	versions, _, _, err := executeQuery(server.Client(), server.URL, "test-token-123", extractor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("expected 1 version, got %d", len(versions))
+	}
+}
+
+func TestExecuteQueryWithoutToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "" {
+			t.Errorf("expected no Authorization header, got %q", auth)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"name":"1.0.0","prerelease":false,"draft":false}]`))
+	}))
+	defer server.Close()
+
+	extractor := func(r *http.Response) (version.Versions, []types.IgnoredVersion, error) {
+		return extractVersionsFromRelease(r, "")
+	}
+
+	versions, _, _, err := executeQuery(server.Client(), server.URL, "", extractor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("expected 1 version, got %d", len(versions))
+	}
+}

--- a/types/params.go
+++ b/types/params.go
@@ -3,6 +3,7 @@ package types
 import (
 	"flag"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 )
@@ -23,6 +24,7 @@ type Params struct {
 	RetryMax          int
 	RetryInitialDelay int
 	RetryMaxDelay     int
+	GitHubToken       string
 }
 
 func (p *Params) Parse(knownSources Sources) error {
@@ -44,8 +46,18 @@ func (p *Params) Parse(knownSources Sources) error {
 	flag.IntVar(&p.RetryMax, "retry-max", 5, "Maximum number of retries for rate-limited requests")
 	flag.IntVar(&p.RetryInitialDelay, "retry-initial-delay", 1000, "Initial retry delay in milliseconds for exponential backoff")
 	flag.IntVar(&p.RetryMaxDelay, "retry-max-delay", 30000, "Maximum retry delay in milliseconds for exponential backoff")
+	flag.StringVar(&p.GitHubToken, "github-token", "",
+		"GitHub API token (overrides GH_TOKEN/GITHUB_TOKEN env vars)")
 
 	flag.Parse()
+
+	if p.GitHubToken == "" {
+		if token := os.Getenv("GH_TOKEN"); token != "" {
+			p.GitHubToken = token
+		} else if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+			p.GitHubToken = token
+		}
+	}
 
 	if p.ShowVersion {
 		return nil


### PR DESCRIPTION
## Summary

Add GitHub API token support so authenticated requests can use the higher rate limit of 5,000 requests/hour instead of the unauthenticated limit of 60 requests/hour.

## Context

GitHub API requests made by this tool (for `github-release` and `github-tag` sources) are currently completely unauthenticated, subject to GitHub's strict rate limit of 60 requests per hour per IP. In CI environments with shared runners, this limit is easily exhausted, causing failures that can only be mitigated by exponential backoff retries -- not a real solution.

By contrast, authenticated requests get 5,000 requests/hour, which is sufficient for virtually all use cases.

## Changes

- Added `GitHubToken` field to `Params` struct and a `--github-token` CLI flag
- Token is resolved with the following priority: `--github-token` flag > `GH_TOKEN` env var > `GITHUB_TOKEN` env var (consistent with GitHub CLI behavior)
- When a token is present, `Authorization: Bearer <token>` header is set on all GitHub API requests
- Added `github-token` input to `action.yml`, passed to the container as the `GH_TOKEN` environment variable

## Use Cases

```yaml
# GitHub Actions workflow
- uses: scylladb-actions/get-version@main
  with:
    source: github-release
    repo: scylladb/scylla
    github-token: ${{ secrets.GITHUB_TOKEN }}
```

```bash
# CLI with environment variable
export GH_TOKEN=ghp_xxxxxxxxxxxx
get-version --source=github-release --repo=scylladb/scylla

# CLI with flag
get-version --source=github-release --repo=scylladb/scylla --github-token=ghp_xxxxxxxxxxxx
```

## Testing

```bash
# Run all tests
go test ./...

# Run only GitHub source tests
go test ./sources/github/
```

New tests verify:
- `TestExecuteQueryWithToken`: Confirms `Authorization: Bearer` header is sent when a token is provided
- `TestExecuteQueryWithoutToken`: Confirms no `Authorization` header is sent when no token is given
